### PR TITLE
Add Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 **/install/**
 bdtools.lock.yml
 compliance_*.json
+AutoStreamClient

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,76 @@
+###########################################
+# ROS2 Foxy base image 
+###########################################
+FROM ubuntu:20.04 AS foxy-base
+
+# Enable noninteractive apt
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install language
+RUN apt-get update && apt-get install -y \
+  locales \
+  && locale-gen en_US.UTF-8 \
+  && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 \
+  && rm -rf /var/lib/apt/lists/*
+ENV LANG en_US.UTF-8
+
+# Install timezone
+RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime \
+  && apt-get update && apt-get install -y \
+  tzdata \
+  && dpkg-reconfigure --frontend noninteractive tzdata \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install ROS2
+RUN apt-get update && apt-get install -y \
+    curl \
+    gnupg2 \
+    lsb-release \
+  && curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null \
+  && apt-get update && apt-get install -y \
+    ros-foxy-ros-base \
+  && rm -rf /var/lib/apt/lists/*
+
+# Set ROS2 environment variables
+ENV ROS_DISTRO=foxy
+ENV AMENT_PREFIX_PATH=/opt/ros/foxy
+ENV COLCON_PREFIX_PATH=/opt/ros/foxy
+ENV LD_LIBRARY_PATH=/opt/ros/foxy/lib
+ENV PATH=/opt/ros/foxy/bin:$PATH
+ENV PYTHONPATH=/opt/ros/foxy/lib/python3.8/site-packages
+ENV ROS_PYTHON_VERSION=3
+ENV ROS_VERSION=2
+
+###########################################
+#  Converter image 
+###########################################
+FROM foxy-base
+
+# Install dependencies for AutoStream converter
+RUN apt-get update && apt-get install -y \
+  wget \ 
+  curl \
+  git \
+  cmake \
+  make \
+  gcc \
+  g++ \
+  ros-foxy-lanelet2 \
+  vim \
+  bash-completion \
+  && rm -rf /var/lib/apt/lists/*
+
+# Copy source files and AutoStreamClient
+COPY . /AutoStreamForAutoware
+
+# Set working directory
+WORKDIR /AutoStreamForAutoware
+
+# Build
+RUN mkdir build \
+    && cd build \
+    && cmake .. -DAUTOSTREAM_CLIENT_SDK_PATH=/AutoStreamForAutoware/AutoStreamClient \
+    && make -j 
+
+ENTRYPOINT [ "/AutoStreamForAutoware/build/Application/AutoStreamToLaneletApp" ]

--- a/README.md
+++ b/README.md
@@ -24,9 +24,11 @@ If you would like to contribute to this project please check the `How to contrib
 # Build Instructions
 - **Dependencies**: See [dependencies.md](docs/dependencies.md) for a list of dependencies
 - **Build**: See [build-unix.md](docs/build-unix.md) to know how to build AutoStream for Autoware Converter
+- **Docker**: See [docker.md](docs/docker.md) for information on how to build a Docker image.
 # Usage
 
 ## Configuration
+### Local
 Below you can see the most relevant parameters in the configuration file that must be updated. 
 Notice that there are more parameters. For a complete documentation, please have a look at the 
 [Application/config/settings.txt](Application/config/settings.txt) file.
@@ -47,12 +49,24 @@ northEastLon: 5.5
 # Name of the output file, i.e., the map that will be generated
 outputFile: /some/file/path/map.osm
 ```
+### Docker
+For Docker, the same configuration file is required. However, the default base directory and output directory are set to `/AutoStreamForAutoware/AutoStreamClient/` and `/config`, respectively. Therefore, `certificatesFile`, `trustedRootCertificateFile`, and `outputFile` in the configuration file should be set as follows:
+
+```bash
+# Certificates needed to enable retrieving map data via AutoStream
+certificatesFile: /AutoStreamForAutoware/AutoStreamClient/certs/AutoStreamRootCAs.pem
+trustedRootCertificateFile: Component/AutoStream/AutoStreamClient/certs/TomTom_AutoStream_Certificate_Production_Signing_Root_CA_1.pem
+
+# Name of the output file, i.e., the map that will be generated
+outputFile: /config/map.osm
+```
 
 ## Getting AutoStream client library and the credentials
 
 As discussed in the above section, to run this converter tool, one must have access to `AutoStream client library`, `api key`, `certificate file` and `trusted root certificate file`. In order to get access to these credentials, [Contact us](mailto:Mariko.Saito@tomtom.com) to sign the Non-Disclosure Agreement (NDA) and Evaluation Agreement (EA) for obtaining the AutoStream client library and the API keys.
 
 ## Running the code
+### Local
 Once the code has been compiled, as explained [here](docs/build-unix.md), the build folder should contain an executable named `AutoStreamToLaneletApp` in the folder `build/Application`. In order to run this executable we must first update the configuration file as explained above.
 
 The executable requires one argument, which is the path to the configuration file.
@@ -62,7 +76,16 @@ cd build
 ```
 After running the executable the converted map for the specified bounding box is available at the 
 location specified in the configuration file.
-
+### Docker
+It is advised to create an empty directory to store all persistent data.
+```bash
+mkdir autostream-converter # This directory will contain all persistent data
+```
+After copying the `settings.txt` to  `autostream-converter`, run the Docker image.
+```bash
+docker run -it --rm -v autostream-converter:/config autostream-converter /config/settings.txt
+```
+The output map will be stored in `autostream-converter` directory.
 # Changelog
 See [CHANGELOG](CHANGELOG.md) for more details.
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,26 @@
+# Docker
+
+With Dockerfile, you can build and run the AutoStream converter for Autoware without having to install dependecies on your system.
+The steps to build and run a docker image are given below.
+
+## System setup 
+- Install Docker by following the instructions on [the official Docker website](https://docs.docker.com/engine/install/).
+- Install other essential tools (Git and Tar)
+  ```bash
+  sudo apt-get update && sudo apt-get install -y git tar
+  ```
+
+## Clone and build the converter
+- Clone the converter source code
+  ```bash
+  git clone https://github.com/tomtom-international/AutoStreamForAutoware.git
+  ```
+- Unpack AutoStreamClient folder into AutoStreamForAutoware (Refer to the instructions on how to get the library and credentials on [README.md](/README.md)
+  ```bash
+  tar -xvf TomTom_AutoStream-linux_gnu_x86_64-<VERSION>-<COMMIT_HASH>.tar.gz -C AutoStreamForAutoware
+  ```
+- Build a Docker image
+  ```bash
+  cd AutoStreamForAutoware
+  docker build -t autostream-coverter:latest .
+  ```


### PR DESCRIPTION
# Description
This PR adds a Dockerfile, which allows users to build and run the converter without having to install all dependencies locally. 

# Testing
The instructions on how to use the Dockerfile are given in `README.md` and `docs/docker.md`. The followings are a summary of those instructions.

## System setup 
- Install Docker by following the instructions on [the official Docker website](https://docs.docker.com/engine/install/).
- Install other essential tools (Git and Tar)
  ```bash
  sudo apt-get update && sudo apt-get install -y git tar
  ```

## Clone and build the converter
- Clone the converter source code
  ```bash
  git clone https://github.com/tomtom-international/AutoStreamForAutoware.git
  ```
- Unpack AutoStreamClient folder into AutoStreamForAutoware.
  ```bash
  tar -xvf TomTom_AutoStream-linux_gnu_x86_64-<VERSION>-<COMMIT_HASH>.tar.gz -C AutoStreamForAutoware
  ```
- Build a Docker image
  ```bash
  cd AutoStreamForAutoware
  docker build -t autostream-coverter:latest .
  ```
## Prepare the configuration file
Create a `settings.txt` file with the following contents.
```bash
# AutoStream key, mandatory for retrieving map data from the AutoStream server
apiKey: <your-key>

# Certificates needed to enable retrieving map data via AutoStream
certificatesFile: /AutoStreamForAutoware/AutoStreamClient/certs/AutoStreamRootCAs.pem
trustedRootCertificateFile: Component/AutoStream/AutoStreamClient/certs/TomTom_AutoStream_Certificate_Production_Signing_Root_CA_1.pem

# Rectangular area for which map data must be converted(bounding box)
southWestLat: 51.48
southWestLon: 5.48
northEastLat: 51.5
northEastLon: 5.5

# Name of the output file, i.e., the map that will be generated
outputFile: /config/map.osm
```

## Run the converter
It is advised to create an empty directory to store all persistent data.
```bash
mkdir autostream-converter # This directory will contain all persistent data
```
After copying the `settings.txt` to  `autostream-converter`, run the Docker image.
```bash
docker run -it --rm -v autostream-converter:/config autostream-converter /config/settings.txt
```
The output map will be stored in `autostream-converter` directory.